### PR TITLE
Fixed a problem on the config event

### DIFF
--- a/Templates/GeneralPluginTemplate/PluginWrapper/gen_WinampPlugin.cpp
+++ b/Templates/GeneralPluginTemplate/PluginWrapper/gen_WinampPlugin.cpp
@@ -37,9 +37,16 @@ int init()
 }
  
 // Called when Configure button in Winamp is clicked
-void config()
+void config(void)
 {
+	try
+	{
 	PluginWrapper::plugin->Config();
+	}
+	catch (Exception^ ex)
+	{
+		System::Windows::Forms::MessageBox::Show(L"An error occured while opening the configuration page! \r\n" + ex->Message);
+	}
 }
  
 // Called when Winamp is quitting


### PR DESCRIPTION
Winamp/WACUP complains, with this popup "This plugin has no configuration options", even the C# code on the Config() event executes fine.

Demonstration of the problem:


![Demonstration](https://cdn.discordapp.com/attachments/426424644342382602/985908596376227900/winamp.original_OoqYm4Uh1U.gif)